### PR TITLE
If build pack is a devDependency, it also needs to be a peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   "peerDependencies": {
     "@atomist/automation-client": "*",
     "@atomist/sdm": "*",
-    "@atomist/sdm-core": "*"
+    "@atomist/sdm-core": "*",
+    "@atomist/sdm-pack-build": "*"
   },
   "devDependencies": {
     "@atomist/automation-client": "1.0.0-RC.1",


### PR DESCRIPTION
because it's used at runtime. Alternately it could be a real dependency