### PR TITLE
Use sdm-core cache capabilities

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -69,18 +69,11 @@ export { IsAtomistAutomationClient } from "./lib/pushtest/nodePushTests";
 export { NodeProjectVersioner } from "./lib/build/nodeProjectVersioner";
 export {
     nodeBuilder,
-    DevelopmentEnvOptions,
     NpmPreparations,
     npmBuilderOptionsFromFile,
-    npmCompilePreparation,
-    npmInstallPreparation,
-    npmVersionPreparation,
     Install,
     NodeModulesProjectListener,
-    NpmInstallProjectListener,
     npmInstallProjectListener,
-    NpmCompileProjectListener,
-    NpmVersionProjectListener,
     CacheScope,
 } from "./lib/build/npmBuilder";
 export {
@@ -89,4 +82,15 @@ export {
 } from "./lib/build/npmProgressReporter";
 export { NodeDefaultOptions } from "./lib/build/nodeOptions";
 export * from "./lib/autofix/eslintAutofix";
+export {
+    npmCompilePreparation,
+    npmInstallPreparation,
+    npmVersionPreparation,
+    NpmInstallProjectListener,
+    NpmCompileProjectListener,
+    NpmVersionProjectListener,
+} from "./lib/listener/npm";
+export {
+    DevelopmentEnvOptions,
+} from "./lib/npm/spawn";
 export { PackageJson } from "./lib/util/PackageJson";

--- a/lib/autofix/npmAuditAutofix.ts
+++ b/lib/autofix/npmAuditAutofix.ts
@@ -25,7 +25,7 @@ import {
     hasFile,
 } from "@atomist/sdm";
 import * as _ from "lodash";
-import { DevelopmentEnvOptions } from "../build/npmBuilder";
+import { DevelopmentEnvOptions } from "../npm/spawn";
 
 const Package = "package.json";
 
@@ -56,11 +56,11 @@ export function npmAuditAutofix(options: NpmAuditOptions = DefaultNpmAuditOption
     return {
         name: "npm audit",
         pushTest: hasFile(Package),
-        transform: async p => {
+        transform: async (p, papi) => {
             if (!isLocalProject(p)) {
                 return p;
             }
-
+            const log = papi.progressLog;
             const cwd = p.baseDir;
             try {
 
@@ -68,7 +68,7 @@ export function npmAuditAutofix(options: NpmAuditOptions = DefaultNpmAuditOption
                 if (options.packageLockOnly === true) {
                     args.push("--package-lock-only");
                 }
-
+                log.write(`Running 'npm audit --fix' in '${cwd}'`);
                 const npmAuditResult = await execPromise(
                     "npm",
                     args,
@@ -76,6 +76,7 @@ export function npmAuditAutofix(options: NpmAuditOptions = DefaultNpmAuditOption
                         cwd,
                         ...DevelopmentEnvOptions,
                     });
+                log.write(`Completed 'npm audit': ${npmAuditResult.stdout}`);
 
                 const npmAudit = JSON.parse(npmAuditResult.stdout) as NpmAuditFixResult;
 

--- a/lib/build/npmBuilder.ts
+++ b/lib/build/npmBuilder.ts
@@ -15,50 +15,41 @@
  */
 
 import {
-    GitProject,
-    guid,
-    LocalProject,
+    ErrorFinder,
     Project,
     RemoteRepoRef,
 } from "@atomist/automation-client";
 import {
-    ExecuteGoalResult,
-    GoalInvocation,
-    GoalProjectListenerEvent,
     GoalProjectListenerRegistration,
-    spawnLog,
     SpawnLogCommand,
-    SpawnLogOptions,
-    SpawnLogResult,
-    SuccessIsReturn0ErrorFinder,
 } from "@atomist/sdm";
-import { readSdmVersion } from "@atomist/sdm-core";
 import {
     Builder,
     spawnBuilder,
     SpawnBuilderOptions,
 } from "@atomist/sdm-pack-build";
 import { AppInfo } from "@atomist/sdm/lib/spi/deploy/Deployment";
-import base64url from "base64url";
-import * as fs from "fs-extra";
-import * as hash from "hasha";
 import * as _ from "lodash";
-import { IsNode } from "../pushtest/nodePushTests";
-import { PackageJson } from "../util/PackageJson";
+import {
+    npmCompilePreparation,
+    npmInstallPreparation,
+    NpmInstallProjectListener,
+    NpmNodeModuledCacheRestore,
+    npmVersionPreparation,
+} from "../listener/npm";
+import { DevelopmentEnvOptions } from "../npm/spawn";
 import { NpmLogInterpreter } from "./npmLogInterpreter";
 
+/* tslint:disable:deprecation */
+
+/** @deprecated use NpmInstallProjectListener */
+export const Install: SpawnLogCommand = { command: "npm", args: ["ci"], options: DevelopmentEnvOptions as any };
+
 /**
- * Options to use when running node commands like npm run compile that require dev dependencies to be installed
+ * Run commands after using [[DevelopmentEnvOptions]] as the default
+ * [[SpawnLogOptions]].
+ * @deprecated Builder interface is deprecated, use npm
  */
-export const DevelopmentEnvOptions: SpawnLogOptions = {
-    env: {
-        ...process.env,
-        NODE_ENV: "development",
-    },
-} as any;
-
-export const Install: SpawnLogCommand = { command: "npm", args: ["ci"], options: DevelopmentEnvOptions };
-
 export function nodeBuilder(...commands: SpawnLogCommand[]): Builder {
     return spawnBuilder(npmBuilderOptions(commands.map(cmd => ({
         command: cmd.command, args: cmd.args, options: {
@@ -68,14 +59,28 @@ export function nodeBuilder(...commands: SpawnLogCommand[]): Builder {
     }))));
 }
 
+/**
+ * When determining if NPM errored, in addition to exit status, look
+ * for common NPM error strings in the logs.
+ */
+export const NpmErrorFinder: ErrorFinder = (code, signal, l) => !!code || !!signal || l.log.startsWith("[error]") || l.log.includes("ERR!");
+
+/**
+ * Generate [[SpawnBuilderOptions]] from the provided NPM commands,
+ * using information from the package.json file in the project.
+ *
+ * @param commands NPM commands to wrap in a [[SpawnBuilderOptions]] object
+ * @return NPM commands usable by spawnBuilder
+ * @deprecated Builder interface is deprecated
+ */
 function npmBuilderOptions(commands: SpawnLogCommand[]): SpawnBuilderOptions {
     return {
         name: "NpmBuilder",
         commands,
-        errorFinder: SuccessIsReturn0ErrorFinder,
+        errorFinder: NpmErrorFinder,
         logInterpreter: NpmLogInterpreter,
         // tslint:disable-next-line:deprecation
-        async projectToAppInfo(p: Project): Promise<AppInfo> {
+        projectToAppInfo: async (p: Project): Promise<AppInfo> => {
             const packageJson = await p.findFile("package.json");
             const content = await packageJson.getContent();
             const pkg = JSON.parse(content);
@@ -84,16 +89,22 @@ function npmBuilderOptions(commands: SpawnLogCommand[]): SpawnBuilderOptions {
     };
 }
 
+/**
+ * Generate [[SpawnBuilderOptions]] from the provided file of NPM
+ * commands, using information from the package.json file in the
+ * project.
+ *
+ * @param commandFile File containing NPM commands to wrap in a [[SpawnBuilderOptions]] object
+ * @return NPM commands usable by spawnBuilder
+ * @deprecated Builder interface is deprecated
+ */
 export function npmBuilderOptionsFromFile(commandFile: string): SpawnBuilderOptions {
     return {
         name: "NpmBuilder",
         commandFile,
-        errorFinder: (code, signal, l) => {
-            return l.log.startsWith("[error]") || l.log.includes("ERR!");
-        },
+        errorFinder: NpmErrorFinder,
         logInterpreter: NpmLogInterpreter,
-        // tslint:disable-next-line:deprecation
-        async projectToAppInfo(p: Project): Promise<AppInfo> {
+        projectToAppInfo: async (p: Project): Promise<AppInfo> => {
             const packageJson = await p.findFile("package.json");
             const content = await packageJson.getContent();
             const pkg = JSON.parse(content);
@@ -102,209 +113,20 @@ export function npmBuilderOptionsFromFile(commandFile: string): SpawnBuilderOpti
     };
 }
 
+/**
+ * Goal preparations when building Node.js projects using NPM.
+ * @deprecated use individual preparations
+ */
 export const NpmPreparations = [npmInstallPreparation, npmVersionPreparation, npmCompilePreparation];
+export const NodeModulesProjectListener = NpmInstallProjectListener;
 
-export async function npmInstallPreparation(p: GitProject, goalInvocation: GoalInvocation): Promise<ExecuteGoalResult> {
-    const hasPackageLock = p.fileExistsSync("package-lock.json");
-    return spawnLog(
-        "npm",
-        [hasPackageLock ? "ci" : "install"],
-        {
-            cwd: p.baseDir,
-            ...DevelopmentEnvOptions,
-            log: goalInvocation.progressLog,
-        });
+/** @deprecated use NpmNodeModuledCacheRestore */
+export function npmInstallProjectListener(options: { scope: CacheScope } = { scope: CacheScope.GoalSet }): GoalProjectListenerRegistration {
+    return NpmNodeModuledCacheRestore;
 }
 
-export async function npmVersionPreparation(p: GitProject, goalInvocation: GoalInvocation): Promise<ExecuteGoalResult> {
-    const sdmGoal = goalInvocation.goalEvent;
-    const version = await readSdmVersion(
-        sdmGoal.repo.owner,
-        sdmGoal.repo.name,
-        sdmGoal.repo.providerId,
-        sdmGoal.sha,
-        sdmGoal.branch,
-        goalInvocation.context);
-    return spawnLog(
-        "npm",
-        ["--no-git-tag-version", "version", version],
-        {
-            cwd: p.baseDir,
-            log: goalInvocation.progressLog,
-        });
-}
-
-export const NpmVersionProjectListener: GoalProjectListenerRegistration = {
-    name: "npm version",
-    pushTest: IsNode,
-    listener: async (p, r, event): Promise<void | ExecuteGoalResult> => {
-        if (GoalProjectListenerEvent.before === event) {
-            return npmVersionPreparation(p, r);
-        }
-    },
-};
-
-export async function npmCompilePreparation(p: GitProject, goalInvocation: GoalInvocation): Promise<ExecuteGoalResult> {
-    if (await hasCompileScriptInPackageJson(p)) {
-        return spawnLog(
-            "npm",
-            ["run", "compile"],
-            {
-                cwd: p.baseDir,
-                ...DevelopmentEnvOptions,
-                log: goalInvocation.progressLog,
-            });
-    } else {
-        return { code: 0 };
-    }
-}
-
-async function hasCompileScriptInPackageJson(p: LocalProject): Promise<boolean> {
-    const rawPj = await p.getFile("package.json");
-    const pj: PackageJson = JSON.parse(await rawPj.getContent()) as PackageJson;
-    return !!pj.scripts && !!pj.scripts.compile;
-}
-
-export const NpmCompileProjectListener: GoalProjectListenerRegistration = {
-    name: "npm compile",
-    pushTest: IsNode,
-    listener: async (p, r): Promise<void | ExecuteGoalResult> => {
-        return npmCompilePreparation(p, r);
-    },
-    events: [GoalProjectListenerEvent.before],
-};
-
-export const NodeModulesProjectListener: GoalProjectListenerRegistration = {
-    name: "npm install",
-    listener: async (p, gi) => {
-        // Check if project has a package.json
-        if (!(await p.hasFile("package.json"))) {
-            return;
-        }
-        return cacheNodeModules(p, gi, { scope: CacheScope.GoalSet });
-    },
-    events: [GoalProjectListenerEvent.before],
-    pushTest: IsNode,
-};
-export const NpmInstallProjectListener = NodeModulesProjectListener;
-
-export function npmInstallProjectListener(options: { scope: CacheScope } = { scope: CacheScope.GoalSet })
-    : GoalProjectListenerRegistration {
-    return {
-        name: "npm install",
-        listener: async (p, gi) => {
-            // Check if project has a package.json
-            if (!(await p.hasFile("package.json"))) {
-                return;
-            }
-            return cacheNodeModules(p, gi, options);
-        },
-        events: [GoalProjectListenerEvent.before],
-        pushTest: IsNode,
-    };
-}
-
+/** @deprecated */
 export enum CacheScope {
     GoalSet,
     Repository,
-}
-
-async function cacheNodeModules(p: GitProject,
-                                gi: GoalInvocation,
-                                options: { scope: CacheScope }): Promise<void | ExecuteGoalResult> {
-    // If project already has a node_modules dir; there is nothing left to do
-    if (await p.hasDirectory("node_modules")) {
-        return;
-    }
-
-    const hasPackageLock = await p.hasFile("package-lock.json");
-
-    let requiresInstall = true;
-    let installed = false;
-
-    const { goalEvent } = gi;
-
-    // Check cache for a previously cached node_modules cache archive
-    let name: string;
-    if (options.scope === CacheScope.GoalSet) {
-        name = goalEvent.goalSetId;
-    } else if (options.scope === CacheScope.Repository) {
-        if (hasPackageLock) {
-            name = base64url.fromBase64(hash(await (await p.getFile("package-lock.json")).getContent(), {
-                algorithm: "md5",
-                encoding: "base64",
-            }));
-        } else {
-            name = base64url.fromBase64(hash(await (await p.getFile("package.json")).getContent(), {
-                algorithm: "md5",
-                encoding: "base64",
-            }));
-        }
-    }
-
-    const cacheFileName = `${_.get(gi, "configuration.sdm.cache.path",
-        "/opt/data")}/${name}-node_modules.tar.gz`;
-    if (_.get(gi, "configuration.sdm.cache.enabled") === true && (await fs.pathExists(cacheFileName))) {
-        const result = await extract(cacheFileName, p, gi);
-        requiresInstall = result.code !== 0;
-    }
-
-    if (requiresInstall) {
-        let result;
-        if (hasPackageLock) {
-            result = await runInstall("ci", p, gi);
-        } else {
-            result = await runInstall("i", p, gi);
-        }
-        installed = result.code === 0;
-    }
-
-    // Cache the node_modules folder
-    if (installed && _.get(gi, "configuration.sdm.cache.enabled") === true) {
-        const tempCacheFileName = `${cacheFileName}.${guid().slice(0, 7)}`;
-        const result = await compress(tempCacheFileName, p, gi);
-        if (result.code === 0) {
-            await fs.move(tempCacheFileName, cacheFileName, { overwrite: true });
-        }
-    }
-}
-
-async function runInstall(cmd: string,
-                          p: GitProject,
-                          gi: GoalInvocation): Promise<SpawnLogResult> {
-    return spawnLog(
-        "npm",
-        [cmd],
-        {
-            cwd: p.baseDir,
-            env: {
-                ...process.env,
-                NODE_ENV: "development",
-            },
-            log: gi.progressLog,
-        });
-}
-
-async function compress(name: string,
-                        p: GitProject,
-                        gi: GoalInvocation): Promise<SpawnLogResult> {
-    return spawnLog(
-        "tar",
-        ["-zcf", name, "node_modules"],
-        {
-            cwd: p.baseDir,
-            log: gi.progressLog,
-        });
-}
-
-async function extract(name: string,
-                       p: GitProject,
-                       gi: GoalInvocation): Promise<SpawnLogResult> {
-    return spawnLog(
-        "tar",
-        ["-xf", name],
-        {
-            cwd: p.baseDir,
-            log: gi.progressLog,
-        });
 }

--- a/lib/listener/npm.ts
+++ b/lib/listener/npm.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    GitProject,
+} from "@atomist/automation-client";
+import {
+    ExecuteGoalResult,
+    GoalInvocation,
+    GoalProjectListenerEvent,
+    GoalProjectListenerRegistration,
+    spawnLog,
+} from "@atomist/sdm";
+import {
+    cachePut,
+    cacheRestore,
+    readSdmVersion,
+} from "@atomist/sdm-core";
+import { npmSpawnLogOptions } from "../npm/spawn";
+import { IsNode } from "../pushtest/nodePushTests";
+
+/**
+ * Update package files with pre-release version for the provided goal
+ * invocation.
+ *
+ * @param p Project to modify package files in
+ * @param gi SDM goal invocation triggering this preparation
+ * @return Success or failure
+ */
+export async function npmVersionPreparation(p: GitProject, gi: GoalInvocation): Promise<ExecuteGoalResult> {
+    const goalEvent = gi.goalEvent;
+    const repo = goalEvent.repo;
+    const version = await readSdmVersion(repo.owner, repo.name, repo.providerId, goalEvent.sha, goalEvent.branch, gi.context);
+    return spawnLog("npm", ["version", "--no-git-tag-version", version], npmSpawnLogOptions(p, gi.progressLog));
+}
+
+/**
+ * Install Node.js dependencies using NPM, runnning `npm install` or
+ * `npm ci`, as appropriate.
+ *
+ * @param p Project to install dependencies for
+ * @param gi SDM goal invocation triggering this preparation
+ * @return Success or failure
+ */
+export async function npmInstallPreparation(p: GitProject, gi: GoalInvocation): Promise<ExecuteGoalResult> {
+    const hasPackageLock = await p.hasFile("package-lock.json");
+    const installCmd = hasPackageLock ? "ci" : "install";
+    return spawnLog("npm", [installCmd], npmSpawnLogOptions(p, gi.progressLog));
+}
+
+/**
+ * Run NPM package compile script, if present.
+ *
+ * @param p Project to run compile script in
+ * @param gi SDM goal invocation triggering this preparation
+ * @return Success or failure
+ */
+export async function npmCompilePreparation(p: GitProject, gi: GoalInvocation): Promise<ExecuteGoalResult> {
+    return spawnLog("npm", ["run", "--if-present", "compile"], npmSpawnLogOptions(p, gi.progressLog));
+}
+
+/**
+ * Project listener that runs [[npmVersionPreparation]] before executing goal.
+ */
+export const NpmVersionProjectListener: GoalProjectListenerRegistration = {
+    events: [GoalProjectListenerEvent.before],
+    listener: npmVersionPreparation,
+    name: "npm version",
+    pushTest: IsNode,
+};
+
+/**
+ * Project listener that runs [[npmInstallPreparation]] before executing goal.
+ */
+export const NpmInstallProjectListener: GoalProjectListenerRegistration = {
+    events: [GoalProjectListenerEvent.before],
+    listener: npmInstallPreparation,
+    name: "npm install",
+    pushTest: IsNode,
+};
+
+/**
+ * Project listener that runs [[npmCompilePreparation]] before executing goal.
+ */
+export const NpmCompileProjectListener: GoalProjectListenerRegistration = {
+    events: [GoalProjectListenerEvent.before],
+    listener: npmCompilePreparation,
+    name: "npm compile",
+    pushTest: IsNode,
+};
+
+const npmNodeModulesCacheClassifier = "npm-node_modules-cache";
+
+/**
+ * Listener that stores the `node_modules` directory in the configured
+ * cache after a goal invocation.
+ */
+export const NpmNodeModulesCachePut = cachePut({
+    entries: [
+        { classifier: npmNodeModulesCacheClassifier, pattern: { directory: "node_modules" } },
+    ],
+    pushTest: IsNode,
+});
+
+/**
+ * Listener that restores the `node_modules` directory from the
+ * configured cache before a goal invocation.
+ */
+export const NpmNodeModuledCacheRestore = cacheRestore({
+    entries: [{ classifier: npmNodeModulesCacheClassifier }],
+    onCacheMiss: {
+        name: "cache-miss-npm-install",
+        listener: npmInstallPreparation,
+    },
+    pushTest: IsNode,
+});
+
+const typescriptCompileCacheClassifier = "ts-compile-cache";
+
+/**
+ * Listener that stores the output from TypeScript compilation in the
+ * configured cache after a goal invocation.
+ */
+export const TypeScriptCompileCachePut = cachePut({
+    entries: [
+        {
+            classifier: typescriptCompileCacheClassifier,
+            pattern: {
+                globPattern: [
+                    "index.{d.ts,js}{,.map}",
+                    "{bin,lib,test}/**/*.{d.ts,js}{,.map}",
+                    "lib/typings/types.ts",
+                ],
+            },
+        },
+    ],
+    pushTest: IsNode,
+});
+
+/**
+ * Listener that restores the output from TypeScript compilation from
+ * the configured cache before a goal invocation.
+ */
+export const TypeScriptCompileCacheRestore = cacheRestore({
+    entries: [{ classifier: typescriptCompileCacheClassifier }],
+    onCacheMiss: {
+        name: "cache-miss-typescript-compile",
+        listener: npmCompilePreparation,
+    },
+    pushTest: IsNode,
+});

--- a/lib/npm/spawn.ts
+++ b/lib/npm/spawn.ts
@@ -14,19 +14,30 @@
  * limitations under the License.
  */
 
+import { GitProject } from "@atomist/automation-client";
 import {
-    allSatisfied,
-    AutofixRegistration,
-    hasFile,
-    spawnAutofix,
+    ProgressLog,
+    SpawnLogOptions,
 } from "@atomist/sdm";
-import { DevelopmentEnvOptions } from "../../npm/spawn";
-import { IsNode } from "../../pushtest/nodePushTests";
-import { IsTypeScript } from "../../pushtest/tsPushTests";
 
-export const TslintAutofix: AutofixRegistration = spawnAutofix(
-    "tslint",
-    allSatisfied(IsTypeScript, IsNode, hasFile("tslint.json")),
-    { ignoreFailure: true },
-    { command: "npm", args: ["run", "--if-present", "lint:fix", "--", "--force"], options: DevelopmentEnvOptions },
-);
+/**
+ * Options to use when running node commands like npm run compile that
+ * require dev dependencies to be installed
+ */
+export const DevelopmentEnvOptions: Partial<SpawnLogOptions> = {
+    env: {
+        ...process.env,
+        NODE_ENV: "development",
+    },
+};
+
+/**
+ * Generate appropriate options for [[spawnLog]] for project and progress log.
+ */
+export function npmSpawnLogOptions(p: GitProject, log: ProgressLog): SpawnLogOptions {
+    return {
+        cwd: p.baseDir,
+        ...DevelopmentEnvOptions,
+        log,
+    };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -196,9 +196,9 @@
       }
     },
     "@atomist/sdm": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@atomist/sdm/-/sdm-1.7.0.tgz",
-      "integrity": "sha512-TDZw8Sbkj0mjxWhBX8sntW/Foh0eb+wPwUTToLKdchfQjCdnLaCbQGM2nRhBEOWJcPDktnGvPkHS6Cz41G7Omg==",
+      "version": "1.7.1-master.20190915225602",
+      "resolved": "https://registry.npmjs.org/@atomist/sdm/-/sdm-1.7.1-master.20190915225602.tgz",
+      "integrity": "sha512-biYlV2CJciw/z4gj54RtGrejheQrg/+l4cOr5+horrx8HQn3Egrov1HnnBth7seP4g/kTGkr5Ju4enP09wcpUQ==",
       "dev": true,
       "requires": {
         "@types/cron": "^1.7.1",
@@ -241,12 +241,6 @@
           "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.138.tgz",
           "integrity": "sha512-A4uJgHz4hakwNBdHNPdxOTkYmXNgmUAKLbXZ7PKGslgeV0Mb8P3BlbYfPovExek1qnod4pDfRbxuzcVs3dlFLg==",
           "dev": true
-        },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
         }
       }
     },
@@ -283,12 +277,6 @@
           "version": "0.12.0",
           "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
           "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
           "dev": true
         },
         "proper-lockfile": {
@@ -636,9 +624,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.17",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.17.tgz",
-          "integrity": "sha512-p/sGgiPaathCfOtqu2fx5Mu1bcjuP8ALFg4xpGgNkcin7LwRyzUKniEHBKdcE1RPsenq5JVPIpMTJSygLboygQ==",
+          "version": "10.14.18",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.18.tgz",
+          "integrity": "sha512-ryO3Q3++yZC/+b8j8BdKd/dn9JlzlHBPdm80656xwYUdmPkpTGTjkAdt6BByiNupGPE8w0FhBgvYy/fX9hRNGQ==",
           "dev": true
         },
         "ws": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "devDependencies": {
     "@atomist/automation-client": "^1.7.0",
-    "@atomist/sdm": "^1.7.0",
+    "@atomist/sdm": "^1.7.1-master.20190915225602",
     "@atomist/sdm-core": "^1.7.0",
     "@atomist/sdm-pack-build": "^1.0.6",
     "@atomist/slack-messages": "^1.1.1",


### PR DESCRIPTION
No longer use internal cache implementation, rather use the standard
implementation in sdm-core.

Reorganize functions and files.  Increase writes to progress log.
Deprecated use of Builder.

Closes #52